### PR TITLE
If no file provided defer file.Close() causes panic.

### DIFF
--- a/sajari-convert.go
+++ b/sajari-convert.go
@@ -39,11 +39,12 @@ func main() {
 
 		// Get uploaded file
 		file, info, err := request.FormFile("input")
-		defer file.Close()
 		if err != nil {
 			log.Println("File upload", err)
 			return
 		}
+
+		defer file.Close()
 
 		// Abort if file doesn't have a mime type
 		if len(info.Header["Content-Type"]) == 0 {


### PR DESCRIPTION
I've moved the defer call after error check to prevent panic when file not found. 